### PR TITLE
UniqueLetterPairs for Alphabet

### DIFF
--- a/internal/pkg/text/alphabet.go
+++ b/internal/pkg/text/alphabet.go
@@ -16,8 +16,9 @@ const EnglishAlphabet = "abcdefghijklmnopqrstuvwxyz"
 
 // Alphabet contains a slice of letters and combinations.
 type Alphabet struct {
-	Combinations []string
-	Letters      []string
+	Combinations      []string
+	Letters           []string
+	uniqueLetterPairs bool
 }
 
 // NewAlphabet creates and configures an Alphabet struct.
@@ -32,6 +33,14 @@ func NewAlphabet(s string, opts ...func(*Alphabet)) *Alphabet {
 
 	a.generateCombinations()
 	return a
+}
+
+// WithUniqueLetterPairs configures the alphabet to not produce repeating
+// letter pairs (e.g. "AA").
+func WithUniqueLetterPairs() func(*Alphabet) {
+	return func(a *Alphabet) {
+		a.uniqueLetterPairs = true
+	}
 }
 
 // WithMixedCase duplicates the original alphabet string so that each letter is
@@ -57,6 +66,10 @@ func (a *Alphabet) generateCombinations() {
 
 	for _, lx := range a.Letters {
 		for _, ly := range a.Letters {
+			if a.uniqueLetterPairs && lx == ly {
+				continue
+			}
+
 			c = append(c, fmt.Sprintf("%s%s", lx, ly))
 		}
 	}

--- a/internal/pkg/text/alphabet_test.go
+++ b/internal/pkg/text/alphabet_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestAlphabetCombinations(t *testing.T) {
 	tests := map[string]struct {
-		input         string
-		want          []string
-		withMixedCase bool
+		input                 string
+		want                  []string
+		withMixedCase         bool
+		withUniqueLetterPairs bool
 	}{
 		"WithoutMixedCase": {
-			input:         "ab",
-			want:          []string{"aa", "ab", "ba", "bb"},
-			withMixedCase: false,
+			input: "ab",
+			want:  []string{"aa", "ab", "ba", "bb"},
 		},
 		"WithMixedCase": {
 			input: "ab",
@@ -26,13 +26,30 @@ func TestAlphabetCombinations(t *testing.T) {
 			},
 			withMixedCase: true,
 		},
+		"WithUniqueLetterPairs": {
+			input:                 "ab",
+			want:                  []string{"ab", "ba"},
+			withUniqueLetterPairs: true,
+		},
+		"WithMixedCaseAndUniqueLetterPairs": {
+			input: "ab",
+			want: []string{
+				"aA", "Aa", "ab", "aB", "Ab", "AB", "ba", "bA", "Ba", "BA", "bB", "Bb",
+			},
+			withMixedCase:         true,
+			withUniqueLetterPairs: true,
+		},
 	}
 
 	for n, test := range tests {
 		t.Run(n, func(subtest *testing.T) {
 			var opts []func(*text.Alphabet)
+
 			if test.withMixedCase {
 				opts = append(opts, text.WithMixedCase())
+			}
+			if test.withUniqueLetterPairs {
+				opts = append(opts, text.WithUniqueLetterPairs())
 			}
 
 			a := text.NewAlphabet(test.input, opts...)


### PR DESCRIPTION
Add support for unique letter pairs when using `Alphabet`, so that letter pairs such as `AA` are avoided.