### PR TITLE
NewEngine - Functional Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,17 @@ import (
 )
 
 func main() {
-	e, err := uci.NewEngine(uci.DefaultCommand(), "/usr/local/bin/stockfish")
+	e, err := uci.NewEngine(
+		uci.DefaultCommand(),
+		"/usr/local/bin/stockfish",
+		uci.InitialiseGame,
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer e.Close()
 
-	err = e.UCI()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = e.UCINewGame()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = e.IsReady()
-	if err != nil {
-		log.Fatal(err)
-	}
+	// ...
 }
 ```
 

--- a/pkg/uci/engine_test.go
+++ b/pkg/uci/engine_test.go
@@ -6,10 +6,36 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/revett/projects/pkg/uci"
 	"github.com/stretchr/testify/assert"
 )
+
+const mockEnginePath = "/path/to/engine"
+
+func TestClose(t *testing.T) {
+	e, err := uci.NewEngine(mockCommander{}, mockEnginePath)
+	assert.NoError(t, err)
+
+	err = e.Close()
+	assert.NoError(t, err)
+}
+
+func TestInitialiseGame(t *testing.T) {
+	m := mockCommander{
+		out: []string{
+			"Stockfish 13 by the Stockfish developers (see AUTHORS file)",
+			"id name Stockfish 13",
+			"id author the Stockfish developers (see AUTHORS file)",
+			"uciok",
+			"readyok",
+		},
+	}
+
+	_, err := uci.NewEngine(m, mockEnginePath, uci.InitialiseGame)
+	assert.NoError(t, err)
+}
 
 func TestIsReady(t *testing.T) {
 	m := mockCommander{
@@ -19,13 +45,15 @@ func TestIsReady(t *testing.T) {
 		},
 	}
 
-	e, err := uci.NewEngine(m, "/path/to/engine")
+	e, err := uci.NewEngine(m, mockEnginePath)
 	assert.NoError(t, err)
 
 	err = e.IsReady()
 	assert.NoError(t, err)
+}
 
-	err = e.Close()
+func TestNewEngine(t *testing.T) {
+	_, err := uci.NewEngine(mockCommander{}, mockEnginePath)
 	assert.NoError(t, err)
 }
 
@@ -38,24 +66,18 @@ func TestUCI(t *testing.T) {
 		},
 	}
 
-	e, err := uci.NewEngine(m, "/path/to/engine")
+	e, err := uci.NewEngine(m, mockEnginePath)
 	assert.NoError(t, err)
 
 	err = e.UCI()
 	assert.NoError(t, err)
-
-	err = e.Close()
-	assert.NoError(t, err)
 }
 
 func TestUCINewGame(t *testing.T) {
-	e, err := uci.NewEngine(mockCommander{}, "/path/to/engine")
+	e, err := uci.NewEngine(mockCommander{}, mockEnginePath)
 	assert.NoError(t, err)
 
 	err = e.UCINewGame()
-	assert.NoError(t, err)
-
-	err = e.Close()
 	assert.NoError(t, err)
 }
 
@@ -78,6 +100,7 @@ func TestMain(m *testing.M) {
 	l := strings.Split(os.Getenv("TEST_CMD_OUTPUT"), ",")
 	for _, s := range l {
 		fmt.Fprintln(os.Stdout, s)
+		time.Sleep(1 * time.Millisecond)
 	}
 
 	os.Exit(0)


### PR DESCRIPTION
Having to call `e.UCI()`, `e.UCINewGame()` and `e.IsReady()` is a pain.

Roll this up in to a single functional option that can be passed when creating the engine: 

```go
package main

import (
	"log"

	"github.com/revett/projects/pkg/uci"
)

func main() {
	e, err := uci.NewEngine(
		uci.DefaultCommand(),
		"/usr/local/bin/stockfish",
		uci.InitialiseGame,
	)
	if err != nil {
		log.Fatal(err)
	}
	defer e.Close()

	// ...
}
```