### PR TITLE
Command Timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"github.com/revett/projects/pkg/uci"
 )
@@ -30,6 +31,7 @@ func main() {
 		uci.DefaultCommand(),
 		"/usr/local/bin/stockfish",
 		uci.InitialiseGame,
+		uci.WithCommandTimeout(100*time.Millisecond),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/uci/engine.go
+++ b/pkg/uci/engine.go
@@ -64,6 +64,15 @@ func InitialiseGame(e *Engine) error {
 	return e.IsReady()
 }
 
+// WithCommandTimeout sets the duration the client will wait for when listening
+// for a given output from the engine.
+func WithCommandTimeout(d time.Duration) func(*Engine) error {
+	return func(e *Engine) error {
+		e.timeout = d
+		return nil
+	}
+}
+
 // Stop ends the chess engine executable.
 func (e Engine) Close() error {
 	if err := e.sendCommand("quit"); err != nil {

--- a/pkg/uci/engine_test.go
+++ b/pkg/uci/engine_test.go
@@ -38,18 +38,38 @@ func TestInitialiseGame(t *testing.T) {
 }
 
 func TestIsReady(t *testing.T) {
-	m := mockCommander{
-		out: []string{
-			"Stockfish 13 by the Stockfish developers (see AUTHORS file)",
-			"readyok",
+	testCases := map[string]struct {
+		cmdOutput []string
+		want      error
+	}{
+		"Success": {
+			cmdOutput: []string{
+				"Stockfish 13 by the Stockfish developers (see AUTHORS file)",
+				"readyok",
+			},
+			want: nil,
+		},
+		"TimeOut": {
+			cmdOutput: []string{
+				"Stockfish 13 by the Stockfish developers (see AUTHORS file)",
+			},
+			want: uci.CommandTimeoutError{},
 		},
 	}
 
-	e, err := uci.NewEngine(m, mockEnginePath)
-	assert.NoError(t, err)
+	for n, tc := range testCases {
+		t.Run(n, func(st *testing.T) {
+			m := mockCommander{
+				out: tc.cmdOutput,
+			}
 
-	err = e.IsReady()
-	assert.NoError(t, err)
+			e, err := uci.NewEngine(m, mockEnginePath)
+			assert.NoError(t, err)
+
+			err = e.IsReady()
+			assert.IsType(t, tc.want, err)
+		})
+	}
 }
 
 func TestNewEngine(t *testing.T) {

--- a/pkg/uci/engine_test.go
+++ b/pkg/uci/engine_test.go
@@ -63,7 +63,9 @@ func TestIsReady(t *testing.T) {
 				out: tc.cmdOutput,
 			}
 
-			e, err := uci.NewEngine(m, mockEnginePath)
+			e, err := uci.NewEngine(
+				m, mockEnginePath, uci.WithCommandTimeout(100*time.Millisecond),
+			)
 			assert.NoError(t, err)
 
 			err = e.IsReady()

--- a/pkg/uci/errors.go
+++ b/pkg/uci/errors.go
@@ -2,11 +2,14 @@ package uci
 
 import "fmt"
 
+// CommandTimeoutError is a custom error for when a timeout occurs when waiting
+// for a response from the engine, after a command has been sent.
 type CommandTimeoutError struct {
 	duration int
 	response string
 }
 
+// Error to satisfy the interface.
 func (c CommandTimeoutError) Error() string {
 	return fmt.Sprintf(
 		"timed out after %d seconds, waiting for '%s' response from engine",

--- a/pkg/uci/errors.go
+++ b/pkg/uci/errors.go
@@ -1,0 +1,16 @@
+package uci
+
+import "fmt"
+
+type CommandTimeoutError struct {
+	duration int
+	response string
+}
+
+func (c CommandTimeoutError) Error() string {
+	return fmt.Sprintf(
+		"timed out after %d seconds, waiting for '%s' response from engine",
+		c.duration,
+		c.response,
+	)
+}


### PR DESCRIPTION
Currently `scanner.Scan()` will block until the expected response is recieved from the engine, for example:

- Send: `isready`
- Receive: `readyok`

If for whatever reason the response is not recieved, then the client will hang. Not great. 

This adds a timeout to `scanner.Scan()` and the option to configure the timeout via a new functional option to `.NewEngine(...)`.

Relevant:
- https://stackoverflow.com/questions/42035104/how-to-unit-test-go-errors