### PR TITLE
Spike: Screenshot CLI w/ Hugo in Nginx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ tailwind-build.css
 # Compiled Parcel output for Hugo
 **/static/js/*.js*
 **/static/js/*.css*
+
+# Public Hugo builds
+web/**/public

--- a/cmd/screenshot/README.md
+++ b/cmd/screenshot/README.md
@@ -1,6 +1,6 @@
 # Screenshot
 
-A CLI for taking a screenshot of a web element using
+A CLI for taking screenshots of web elements using
 [Selenium](https://github.com/SeleniumHQ/docker-selenium) (Docker) and the
 [tebeka/selenium](https://github.com/tebeka/selenium) package.
 
@@ -9,7 +9,7 @@ A CLI for taking a screenshot of a web element using
 Start a Firefox Selenium container:
 
 ```bash
-docker run -d -p 4444:4444 -p 7900:7900 --shm-size 2g selenium/standalone-firefox:4.0.0-beta-3-prerelease-20210402
+docker run -d -p 4444:4444 -p 7900:7900 selenium/standalone-firefox
 ```
 
 > **[Full Documentation →](https://github.com/SeleniumHQ/docker-selenium)**
@@ -22,19 +22,21 @@ Build the binary:
 make run cmd=screenshot
 ```
 
+> Using the **root** Makefile.
+
 View CLI usage:
 
 ```bash
 cmd/screenshot/screenshot
 ```
 
-## Example
+### Example
 
 ```bash
 cmd/screenshot/screenshot -u https://news.ycombinator.com/ element -s="#hnmain"
 ```
 
-## Debugging
+### Debugging
 
 View what is happening inside the Selenium container by visiting
 [http://localhost:7900](http://localhost:7900), the default password is

--- a/deployments/thruhike/docker-compose.yml
+++ b/deployments/thruhike/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.3"
+services:
+  nginx:
+    image: nginx
+    ports:
+      - 8080:80
+    volumes:
+      - ../../web/thruhike/public:/usr/share/nginx/html:ro
+  selenium:
+    image: selenium/standalone-firefox:4.0.0-beta-3-prerelease-20210402
+    links:
+      - nginx
+    ports:
+      - 4444:4444
+      - 7900:7900

--- a/internal/screenshot/cmd/element.go
+++ b/internal/screenshot/cmd/element.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"time"
 
 	"github.com/revett/projects/internal/screenshot/browser"
 	"github.com/revett/projects/internal/screenshot/imgio"
@@ -53,6 +54,10 @@ func elementAction(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// BUG(revett): Wait for Mapbox map to fully load, fix for .WaitForElement
+	// required.
+	time.Sleep(5 * time.Second)
 
 	bytes, err := om.ScreenshotElement(c.String("selector"))
 	if err != nil {

--- a/internal/screenshot/cmd/element.go
+++ b/internal/screenshot/cmd/element.go
@@ -55,9 +55,10 @@ func elementAction(c *cli.Context) error {
 		return err
 	}
 
+	// nolint:godox
 	// BUG(revett): Wait for Mapbox map to fully load, fix for .WaitForElement
 	// required.
-	time.Sleep(5 * time.Second)
+	time.Sleep(5 * time.Second) // nolint:gomnd
 
 	bytes, err := om.ScreenshotElement(c.String("selector"))
 	if err != nil {

--- a/web/thruhike/Makefile
+++ b/web/thruhike/Makefile
@@ -3,7 +3,19 @@ DEFAULT: run
 build:
 	hugo --buildDrafts --minify --verbose
 
-js:
+build-docker:
+	hugo --buildDrafts --baseURL "http://nginx:80/" --minify --verbose
+
+compose-down:
+	docker-compose -f ../../deployments/thruhike/docker-compose.yml down
+
+compose-up:
+	docker-compose -f ../../deployments/thruhike/docker-compose.yml up -d
+
+js-build:
+	MAPBOX_TOKEN=$(MAPBOX_TOKEN) ./node_modules/parcel-bundler/bin/cli.js build -d static/js assets/js/*.js
+
+js-watch:
 	MAPBOX_TOKEN=$(MAPBOX_TOKEN) ./node_modules/parcel-bundler/bin/cli.js watch -d static/js assets/js/*.js
 
 run:


### PR DESCRIPTION
- Make use of the screenshot CLI to take a screenshot of a Mapbox map
- Build Hugo site for Docker Compose stack
- Set up Docker Compose stack with built Hugo site served via Nginx
- Configure Selenium to use Nginx container

## Screenshot

![image](https://user-images.githubusercontent.com/2796074/114942387-5ff43b80-9e3c-11eb-98e6-2837e3187d02.png)
