### PR TITLE
Check LocalStorage in CLI

### DIFF
--- a/internal/mapbox-screenshot/cmd/capture.go
+++ b/internal/mapbox-screenshot/cmd/capture.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/url"
-	"time"
 
 	"github.com/revett/projects/internal/mapbox-screenshot/browser"
 	"github.com/revett/projects/internal/mapbox-screenshot/imgio"
@@ -66,11 +65,6 @@ func captureElements(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	// nolint:godox
-	// BUG(revett): Wait for Mapbox map to fully load, fix for .WaitForElement
-	// required.
-	time.Sleep(8 * time.Second) // nolint:gomnd
 
 	bytes, err := om.ScreenshotElement(selector)
 	if err != nil {

--- a/internal/mapbox-screenshot/page/condition.go
+++ b/internal/mapbox-screenshot/page/condition.go
@@ -1,16 +1,28 @@
 package page
 
-import "github.com/tebeka/selenium"
+import (
+	"fmt"
+
+	"github.com/tebeka/selenium"
+)
+
+const localStorageKey = "mapbox.StylesLoaded"
 
 // ElementExistsCondition returns a selenium.Condition which checks if a web
 // element exists using a CSS selector.
 func ElementExistsCondition(s string) selenium.Condition {
 	return func(wd selenium.WebDriver) (bool, error) {
-		om := New(wd)
-		if _, err := om.FindElement(s); err != nil {
+		s := fmt.Sprintf("return localStorage.getItem(\"%s\")", localStorageKey)
+
+		v, err := wd.ExecuteScript(s, nil)
+		if err != nil {
 			return false, err
 		}
 
-		return true, nil
+		if v == "true" {
+			return true, nil
+		}
+
+		return false, nil
 	}
 }


### PR DESCRIPTION
Now that the Mapbox map sets the key in `localStorage` when styles are complete, the CLI can now check for that instead of the generic check of if the element is present. 